### PR TITLE
Make glib dependency optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ version = "0.3.2"
 [dependencies.glib]
 git = "https://github.com/gtk-rs/glib"
 version = "0.1.1"
+optional = true
 
 [dependencies]
 libc = "0.2"

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -2,10 +2,10 @@
 // See the COPYRIGHT file at the top-level directory of this distribution.
 // Licensed under the MIT license, see the LICENSE file or <http://opensource.org/licenses/MIT>
 
-use glib::translate::*;
 use std::clone::Clone;
 use std::cmp::PartialEq;
 use std::ops::Drop;
+use std::ffi::{CStr, CString};
 use ffi;
 
 pub use ffi::enums::{
@@ -180,7 +180,8 @@ impl FontFace {
     pub fn toy_create(family: &str, slant: FontSlant, weight: FontWeight) -> FontFace {
         let font_face = FontFace(
             unsafe {
-                ffi::cairo_toy_font_face_create(family.to_glib_none().0, slant, weight)
+                let family_cstring = CString::new(family).unwrap();
+                ffi::cairo_toy_font_face_create(family_cstring.as_ptr(), slant, weight)
             }
         );
         font_face.ensure_status();
@@ -189,7 +190,12 @@ impl FontFace {
 
     pub fn toy_get_family(&self) -> Option<String> {
         unsafe {
-            from_glib_none(ffi::cairo_toy_font_face_get_family(self.get_ptr()))
+            let family = ffi::cairo_toy_font_face_get_family(self.get_ptr());
+            if family.is_null() {
+                None
+            } else {
+                Some(CStr::from_ptr(family).to_string_lossy().into_owned())
+            }
         }
     }
 

--- a/src/image_surface.rs
+++ b/src/image_surface.rs
@@ -5,6 +5,7 @@
 use std::ops::{Deref, DerefMut};
 use std::slice;
 
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
@@ -29,8 +30,12 @@ impl ImageSurface {
         }
     }
 
+    unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> ImageSurface {
+        Self::from(Surface::from_raw_full(ptr)).unwrap()
+    }
+
     pub fn create(format: Format, width: i32, height: i32) -> ImageSurface {
-        unsafe { from_glib_full(ffi::cairo_image_surface_create(format, width, height)) }
+        unsafe { Self::from_raw_full(ffi::cairo_image_surface_create(format, width, height)) }
     }
 
     pub fn create_for_data<F>(data: Box<[u8]>, free: F, format: Format, width: i32, height: i32,
@@ -40,7 +45,7 @@ impl ImageSurface {
         unsafe {
             let mut data = Box::new(AsyncBorrow::new(data, free));
             let ptr = (*data).as_mut().as_mut_ptr();
-            let surface = ImageSurface::from_glib_full(
+            let surface = ImageSurface::from_raw_full(
                 ffi::cairo_image_surface_create_for_data(ptr, format, width, height, stride));
             surface.set_user_data(&IMAGE_SURFACE_DATA, data).unwrap();
             surface
@@ -49,7 +54,7 @@ impl ImageSurface {
 
     pub fn get_data(&mut self) -> Result<ImageSurfaceData, BorrowError> {
         unsafe {
-            if ffi::cairo_surface_get_reference_count(self.to_glib_none().0) > 1 {
+            if ffi::cairo_surface_get_reference_count(self.to_raw_none()) > 1 {
                 return Err(BorrowError::NonExclusive)
             }
             self.flush();
@@ -57,7 +62,7 @@ impl ImageSurface {
                 Status::Success => (),
                 status => return Err(BorrowError::from(status)),
             }
-            if ffi::cairo_image_surface_get_data(self.to_glib_none().0).is_null() {
+            if ffi::cairo_image_surface_get_data(self.to_raw_none()).is_null() {
                 return Err(BorrowError::from(Status::SurfaceFinished))
             }
             Ok(ImageSurfaceData::new(self))
@@ -65,24 +70,25 @@ impl ImageSurface {
     }
 
     pub fn get_format(&self) -> Format {
-        unsafe { ffi::cairo_image_surface_get_format(self.to_glib_none().0) }
+        unsafe { ffi::cairo_image_surface_get_format(self.to_raw_none()) }
     }
 
     pub fn get_height(&self) -> i32 {
-        unsafe { ffi::cairo_image_surface_get_height(self.to_glib_none().0) }
+        unsafe { ffi::cairo_image_surface_get_height(self.to_raw_none()) }
     }
 
     pub fn get_stride(&self) -> i32 {
-        unsafe { ffi::cairo_image_surface_get_stride(self.to_glib_none().0) }
+        unsafe { ffi::cairo_image_surface_get_stride(self.to_raw_none()) }
     }
 
     pub fn get_width(&self) -> i32 {
-        unsafe { ffi::cairo_image_surface_get_width(self.to_glib_none().0) }
+        unsafe { ffi::cairo_image_surface_get_width(self.to_raw_none()) }
     }
 }
 
 static IMAGE_SURFACE_DATA: () = ();
 
+#[cfg(feature = "glib")]
 impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for ImageSurface {
     type Storage = &'a Surface;
 
@@ -93,6 +99,7 @@ impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for ImageSurface {
     }
 }
 
+#[cfg(feature = "glib")]
 impl FromGlibPtr<*mut ffi::cairo_surface_t> for ImageSurface {
     #[inline]
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> ImageSurface {
@@ -101,7 +108,7 @@ impl FromGlibPtr<*mut ffi::cairo_surface_t> for ImageSurface {
 
     #[inline]
     unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> ImageSurface {
-        Self::from(from_glib_full(ptr)).unwrap()
+        Self::from_raw_full(ptr)
     }
 }
 
@@ -121,7 +128,7 @@ impl Deref for ImageSurface {
 
 impl Clone for ImageSurface {
     fn clone(&self) -> ImageSurface {
-        unsafe { from_glib_none(self.to_glib_none().0) }
+        ImageSurface(self.0.clone())
     }
 }
 
@@ -134,7 +141,7 @@ pub struct ImageSurfaceData<'a> {
 impl<'a> ImageSurfaceData<'a> {
     fn new(surface: &'a mut ImageSurface) -> ImageSurfaceData<'a> {
         unsafe {
-            let ptr = ffi::cairo_image_surface_get_data(surface.to_glib_none().0);
+            let ptr = ffi::cairo_image_surface_get_data(surface.to_raw_none());
             debug_assert!(!ptr.is_null());
             let len = (surface.get_stride() as usize) * (surface.get_height() as usize);
             ImageSurfaceData {
@@ -149,7 +156,7 @@ impl<'a> ImageSurfaceData<'a> {
 impl<'a> Drop for ImageSurfaceData<'a> {
     fn drop(&mut self) {
         if self.dirty {
-            unsafe { ffi::cairo_surface_mark_dirty(self.surface.to_glib_none().0) }
+            unsafe { ffi::cairo_surface_mark_dirty(self.surface.to_raw_none()) }
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 
 extern crate cairo_sys as ffi;
 extern crate libc;
-extern crate glib;
 extern crate c_vec;
+
+#[cfg(feature = "glib")]
+extern crate glib;
 
 pub use ffi::enums;
 pub use ffi::cairo_rectangle_t as Rectangle;

--- a/src/patterns.rs
+++ b/src/patterns.rs
@@ -7,7 +7,6 @@
 use libc::{c_double, c_int, c_uint};
 use std::ptr;
 use std::mem::transmute;
-use glib::translate::*;
 use ffi::enums::{
     Extend,
     Filter,
@@ -269,7 +268,7 @@ pattern_type!(SurfacePattern);
 impl SurfacePattern {
     pub fn create<T: AsRef<Surface>>(surface: &T) -> SurfacePattern {
         SurfacePattern::wrap(unsafe {
-            ffi::cairo_pattern_create_for_surface(surface.as_ref().to_glib_none().0)
+            ffi::cairo_pattern_create_for_surface(surface.as_ref().to_raw_none())
         })
     }
 
@@ -277,7 +276,7 @@ impl SurfacePattern {
         unsafe {
             let mut surface_ptr: *mut cairo_surface_t = ptr::null_mut();
             ffi::cairo_pattern_get_surface(self.pointer, &mut surface_ptr).ensure_valid();
-            Surface::from_glib_none(surface_ptr)
+            Surface::from_raw_none(surface_ptr)
         }
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,5 +1,8 @@
+#[cfg(feature = "glib")]
 use ffi;
+#[cfg(feature = "glib")]
 use glib::translate::*;
+#[cfg(feature = "glib")]
 use std::mem;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -11,6 +14,7 @@ pub struct RectangleInt {
     pub height: i32,
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl Uninitialized for RectangleInt {
     #[inline]
@@ -19,6 +23,7 @@ impl Uninitialized for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a Self;
@@ -30,6 +35,7 @@ impl<'a> ToGlibPtr<'a, *const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     type Storage = &'a mut Self;
@@ -41,6 +47,7 @@ impl<'a> ToGlibPtrMut<'a, *mut ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl FromGlibPtr<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *const ffi::cairo_rectangle_int_t) -> Self {
@@ -52,6 +59,7 @@ impl FromGlibPtr<*const ffi::cairo_rectangle_int_t> for RectangleInt {
     }
 }
 
+#[cfg(feature = "glib")]
 #[doc(hidden)]
 impl FromGlibPtr<*mut ffi::cairo_rectangle_int_t> for RectangleInt {
     unsafe fn from_glib_none(ptr: *mut ffi::cairo_rectangle_int_t) -> Self {

--- a/src/surface.rs
+++ b/src/surface.rs
@@ -5,6 +5,7 @@
 use std::mem;
 use libc::c_void;
 
+#[cfg(feature = "glib")]
 use glib::translate::*;
 use ffi;
 use ffi::enums::{
@@ -17,36 +18,53 @@ use ffi::enums::{
 pub struct Surface(*mut ffi::cairo_surface_t);
 
 impl Surface {
-    pub fn status(&self) -> Status {
-        unsafe { ffi::cairo_surface_status(self.to_glib_none().0) }
-    }
-
-    pub fn create_similar(&self, content: Content, width: i32, height: i32) -> Surface {
-        unsafe { from_glib_full(ffi::cairo_surface_create_similar(self.to_glib_none().0, content, width, height)) }
-    }
-}
-
-impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Surface {
-    type Storage = &'a Surface;
-
-    #[inline]
-    fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
-        Stash(self.0, self)
-    }
-}
-
-impl FromGlibPtr<*mut ffi::cairo_surface_t> for Surface {
-    #[inline]
-    unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
+    #[doc(hidden)]
+    pub unsafe fn from_raw_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
         assert!(!ptr.is_null());
         ffi::cairo_surface_reference(ptr);
         Surface(ptr)
     }
 
-    #[inline]
-    unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Surface {
+    #[doc(hidden)]
+    pub unsafe fn from_raw_full(ptr: *mut ffi::cairo_surface_t) -> Surface {
         assert!(!ptr.is_null());
         Surface(ptr)
+    }
+
+    #[doc(hidden)]
+    pub fn to_raw_none(&self) -> *mut ffi::cairo_surface_t {
+        self.0
+    }
+
+    pub fn status(&self) -> Status {
+        unsafe { ffi::cairo_surface_status(self.0) }
+    }
+
+    pub fn create_similar(&self, content: Content, width: i32, height: i32) -> Surface {
+        unsafe { Self::from_raw_full(ffi::cairo_surface_create_similar(self.0, content, width, height)) }
+    }
+}
+
+#[cfg(feature = "glib")]
+impl<'a> ToGlibPtr<'a, *mut ffi::cairo_surface_t> for Surface {
+    type Storage = &'a Surface;
+
+    #[inline]
+    fn to_glib_none(&'a self) -> Stash<'a, *mut ffi::cairo_surface_t, Self> {
+        Stash(self.to_raw_none(), self)
+    }
+}
+
+#[cfg(feature = "glib")]
+impl FromGlibPtr<*mut ffi::cairo_surface_t> for Surface {
+    #[inline]
+    unsafe fn from_glib_none(ptr: *mut ffi::cairo_surface_t) -> Surface {
+        Self::from_raw_none(ptr)
+    }
+
+    #[inline]
+    unsafe fn from_glib_full(ptr: *mut ffi::cairo_surface_t) -> Surface {
+        Self::from_raw_full(ptr)
     }
 }
 
@@ -58,7 +76,7 @@ impl AsRef<Surface> for Surface {
 
 impl Clone for Surface {
     fn clone(&self) -> Surface {
-        unsafe { from_glib_none(self.to_glib_none().0) }
+        unsafe { Self::from_raw_none(self.0) }
     }
 }
 


### PR DESCRIPTION
The cairo bindings used the glib::translate traits to handle internal
reference counting discipline. However, these are not actually
required, and should be possible to use cairo without a dependency on
glib. This patch makes the dependency optional, and changes the
implementation to not use the glib traits internally.